### PR TITLE
do not print gcc version on module load

### DIFF
--- a/hope/options.py
+++ b/hope/options.py
@@ -81,4 +81,3 @@ def _check_version(compiler_name, compiler_exec):
             raise UnsupportedCompilerException("Compiler '%s' with version '%s' is not supported. Minimum version is '%s'"%(compiler_name, 
                                                                                                                             version, 
                                                                                                                             SUPPORTED_VERSIONS[compiler_name]))
-        print(version)


### PR DESCRIPTION
when I import the module it prints the gcc version

```
In [1]: from hope import jit
4.9.1
```
