### PR TITLE
py3k: fixed version detection

### DIFF
--- a/hope/options.py
+++ b/hope/options.py
@@ -73,10 +73,9 @@ def get_cxxflags():
 
 def _check_version(compiler_name, compiler_exec):
     if compiler_name in SUPPORTED_VERSIONS.keys():
-        import commands
+        import subprocess
         from distutils.version import StrictVersion
-
-        version = commands.getoutput(compiler_exec + ' -dumpversion')
+        version = subprocess.check_output(compiler_exec + ' -dumpversion', shell=True).decode().rstrip()
         if StrictVersion(version) < StrictVersion(SUPPORTED_VERSIONS[compiler_name]):
             raise UnsupportedCompilerException("Compiler '%s' with version '%s' is not supported. Minimum version is '%s'"%(compiler_name, 
                                                                                                                             version, 


### PR DESCRIPTION
the commands modules was removed in python3, use subprocess instead
