### PR TITLE
Using `subprocess` instead of deprecated `commands`

### DIFF
--- a/hope/options.py
+++ b/hope/options.py
@@ -73,10 +73,10 @@ def get_cxxflags():
 
 def _check_version(compiler_name, compiler_exec):
     if compiler_name in SUPPORTED_VERSIONS.keys():
-        import commands
+        import subprocess
         from distutils.version import StrictVersion
 
-        version = commands.getoutput(compiler_exec + ' -dumpversion')
+        version = subprocess.check_output([compiler_exec, '-dumpversion']).decode('ascii')
         if StrictVersion(version) < StrictVersion(SUPPORTED_VERSIONS[compiler_name]):
             raise UnsupportedCompilerException("Compiler '%s' with version '%s' is not supported. Minimum version is '%s'"%(compiler_name, 
                                                                                                                             version, 


### PR DESCRIPTION
`commands` modules has been deprecated since Py2.6 and missing since Py3.0.
