### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/hope/_generator.py
+++ b/hope/_generator.py
@@ -672,7 +672,7 @@ def _run_fkt_code(modtoken):
     code += "\t\tPyObject * signatures = Py_BuildValue(\"(sO)\", \"{0}\", args);\n".format(pickled)
     code += "\t\tif (!signatures) {\n"
 
-    # TODO: make all exceptions reasonamble: http://docs.python.org/2/c-api/exceptions.html
+    # TODO: make all exceptions reasonable: http://docs.python.org/2/c-api/exceptions.html
     code += "\t\t\tPyErr_SetString(PyExc_ValueError, \"Error building signature string for {0}\");\n".format(modtoken.main)
     code += "\t\t\treturn NULL;\n"
     code += "\t\t}\n"

--- a/hope/_transformer.py
+++ b/hope/_transformer.py
@@ -752,7 +752,7 @@ class ASTTransformer(ast.NodeVisitor):
 def get_fkt_ast(fkt):
     """
     Creates a AST form the given function by getting the source of the function 
-    by inspection, removing unneccesary indentations and passing the string 
+    by inspection, removing unnecessary indentations and passing the string 
     representation to the :py:mod:`ast` module. 
     
     :param fkt: Function object to be used

--- a/hope/_wrapper.py
+++ b/hope/_wrapper.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2013 ETH Zurich, Institute of Astronomy, Lukas Gamper <lukas.gamper@usystems.ch>
 
-# setuptools have a proplem with the unicode_literals in python 2, so skip unicode_literals
+# setuptools have a problem with the unicode_literals in python 2, so skip unicode_literals
 from __future__ import print_function, division, absolute_import
 
 

--- a/hope/config.py
+++ b/hope/config.py
@@ -40,7 +40,7 @@ Check if indeces are out of bounds
 hopeless = False
 """ 
 Disable hope. If hope.config.hopeless is True, hope.jit return the original function.
-Use this function for debug purpos
+Use this function for debug purpose
 """
 
 # make readable cpp file, but typecasting is not exactly the same as in numpy - this flag is private

--- a/hope/jit.py
+++ b/hope/jit.py
@@ -21,7 +21,7 @@ from hope._wrapper import get_fkt_hash
 # TODO: implement self, self.cost, self.fkt
 # TODO: replace function in global namespace by c pointer to get the native speed on the first run
 # TODO: make two versions for np.int_ and int
-# TODO: make hope.interp with retuns a callable object with 2^n basepoints and c pendant
+# TODO: make hope.interp with returns a callable object with 2^n basepoints and c pendant
 # TODO: if dtype of argument is alreadu correct, do not cast it in c code
 # TODO: add test for subscrpto with all types to get the same semantics
 # TODO: controll structures
@@ -33,10 +33,10 @@ from hope._wrapper import get_fkt_hash
 # TODO: use https://github.com/workhorsy/py-cpuinfo/blob/master/cpuinfo.py to detect features
 # TODO: other code generator: http://documen.tician.de/codepy/jit.html#module-codepy.jit
 # TODO: make ufunc decorator http://docs.scipy.org/doc/numpy/reference/ufuncs.html like numba http://numba.pydata.org/numba-doc/0.12.1/ufuncs.html
-# TODO: optimize pow with interger powers to multipications
+# TODO: optimize pow with interger powers to multiplications
 # TODO: make tests for _dump
 # TODO: add constants/class constants to hope
-# TODO: use sympy to simpify and Common Subexpression Detection
+# TODO: use sympy to simplify and Common Subexpression Detection
 # 		http://docs.sympy.org/latest/modules/rewriting.html
 # 		http://docs.sympy.org/latest/modules/core.html#module-sympy.core.sympify
 

--- a/hope/options.py
+++ b/hope/options.py
@@ -28,7 +28,7 @@ def enableUnsaveMath():
     Enable the fast-math and associative-math flags in the c++ compiler.
 
     .. warning::
-        using these flags, ``nan`` and ``inf`` are not propageted properly.
+        using these flags, ``nan`` and ``inf`` are not propagated properly.
         Only use these flags if you know what you are doing!
     """
     config.cxxflags += ["-fassociative-math", "-ffast-math"]


### PR DESCRIPTION
There are small typos in:
- hope/_generator.py
- hope/_transformer.py
- hope/_wrapper.py
- hope/config.py
- hope/jit.py
- hope/options.py

Fixes:
- Should read `unnecessary` rather than `unneccesary`.
- Should read `simplify` rather than `simpify`.
- Should read `returns` rather than `retuns`.
- Should read `reasonable` rather than `reasonamble`.
- Should read `purpose` rather than `purpos`.
- Should read `propagated` rather than `propageted`.
- Should read `problem` rather than `proplem`.
- Should read `multiplications` rather than `multipications`.

Closes #58